### PR TITLE
Fix the SQL examples for inserting data with all fields in the DuckDB, GEL, PostgreSQL, and SQLite documentation

### DIFF
--- a/src/content/docs/duckdb/sql-values.mdx
+++ b/src/content/docs/duckdb/sql-values.mdx
@@ -23,7 +23,7 @@ await sql`insert into "users" ("name", "email", "age") values ${values}`;
 ```
 ```sql
 insert into "users" ("name") values ('Dan');
-insert into "users" ("name") values ('Dan', 'dan@acme.com', 25);
+insert into "users" ("name", "email", "age") values ('Dan', 'dan@acme.com', 25);
 ```
 </Section>
 <Section>

--- a/src/content/docs/gel/sql-values.mdx
+++ b/src/content/docs/gel/sql-values.mdx
@@ -23,7 +23,7 @@ await sql`insert into "users" ("name", "email", "age") values ${values}`;
 ```
 ```sql
 insert into "users" ("name") values ('Dan');
-insert into "users" ("name") values ('Dan', 'dan@acme.com', 25);
+insert into "users" ("name", "email", "age") values ('Dan', 'dan@acme.com', 25);
 ```
 </Section>
 <Section>

--- a/src/content/docs/pg/sql-values.mdx
+++ b/src/content/docs/pg/sql-values.mdx
@@ -23,7 +23,7 @@ await sql`insert into "users" ("name", "email", "age") values ${values}`;
 ```
 ```sql
 insert into "users" ("name") values ('Dan');
-insert into "users" ("name") values ('Dan', 'dan@acme.com', 25);
+insert into "users" ("name", "email", "age") values ('Dan', 'dan@acme.com', 25);
 ```
 </Section>
 <Section>

--- a/src/content/docs/sqlite/sql-values.mdx
+++ b/src/content/docs/sqlite/sql-values.mdx
@@ -23,7 +23,7 @@ await sql`insert into "users" ("name", "email", "age") values ${values}`;
 ```
 ```sql
 insert into "users" ("name") values ('Dan');
-insert into "users" ("name") values ('Dan', 'dan@acme.com', 25);
+insert into "users" ("name", "email", "age") values ('Dan', 'dan@acme.com', 25);
 ```
 </Section>
 <Section>

--- a/src/content/landing/showcase.mdx
+++ b/src/content/landing/showcase.mdx
@@ -61,7 +61,7 @@ await sql`insert into "users" ("name", "email", "age") values ${values}`;
 ```
 ```sql
 insert into "users" ("name") values ('Dan');
-insert into "users" ("name") values ('Dan', 'dan@acme.com', 25);
+insert into "users" ("name", "email", "age") values ('Dan', 'dan@acme.com', 25);
 ```
 </Section>
 


### PR DESCRIPTION
Fix the SQL examples for inserting data with all fields in the DuckDB, GEL, PostgreSQL, and SQLite documentation